### PR TITLE
Add basic streaming agent demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# agent_demo
+# Agent Demo Project
+
+This is a simple demonstration of a web UI communicating with a Python backend that streams responses. The UI lets you compose prompts, select tools and chat with the backend.
+
+## Features
+
+- System and optional additional prompt fields
+- Chat history area that fills gradually as the backend streams its response
+- Field for user messages
+- Drag & drop (or click) interface to add/remove tools
+- Backend implemented with FastAPI and WebSocket streaming
+
+## Running
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   uvicorn server:app --reload
+   ```
+3. Open your browser at [http://localhost:8000](http://localhost:8000) to see the UI.
+
+When you send a message the backend will stream a dummy response word by word so the chat history updates gradually.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/server.py
+++ b/server.py
@@ -1,0 +1,32 @@
+import asyncio
+import json
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+with open("static/index.html", "r") as f:
+    index_html = f.read()
+
+@app.get("/")
+async def get_index():
+    return HTMLResponse(index_html)
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            payload = json.loads(data)
+            user_msg = payload.get("userMsg", "")
+            # Simple streaming: echo each word with delay
+            response = f"Agent: You said '{user_msg}'. Using tools {payload.get('tools', [])}\n"
+            for word in response.split():
+                await websocket.send_text(word + " ")
+                await asyncio.sleep(0.3)
+            await websocket.send_text("\n")
+    except WebSocketDisconnect:
+        pass

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Agent Demo</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        textarea { width: 100%; box-sizing: border-box; margin-bottom: 10px; }
+        #history { height: 300px; }
+        #tools, #available-tools { display: flex; flex-wrap: wrap; gap: 5px; border: 1px solid #ccc; padding: 10px; min-height: 50px; }
+        .tool { padding: 5px 10px; background: #eee; border: 1px solid #ccc; cursor: pointer; user-select: none; }
+    </style>
+</head>
+<body>
+<h1>Agent Demo</h1>
+<label>System Prompt:</label>
+<textarea id="system-prompt"></textarea>
+<label><input type="checkbox" id="enable-extra" checked> Additional Prompt:</label>
+<textarea id="extra-prompt"></textarea>
+<label>Chat History:</label>
+<textarea id="history" readonly></textarea>
+<label>User Message:</label>
+<input type="text" id="user-msg" style="width:100%;"/>
+
+<h3>Available Tools</h3>
+<div id="available-tools"></div>
+<h3>Selected Tools</h3>
+<div id="tools"></div>
+
+<button id="send-btn">Send</button>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,62 @@
+const availableTools = ["calculator", "search", "wikipedia", "weather"]; // sample tools
+
+function makeTool(name) {
+    const div = document.createElement('div');
+    div.className = 'tool';
+    div.textContent = name;
+    div.draggable = true;
+    div.addEventListener('dragstart', e => {
+        e.dataTransfer.setData('text/plain', name);
+    });
+    div.addEventListener('click', () => {
+        const parent = div.parentElement.id === 'available-tools' ? document.getElementById('tools') : document.getElementById('available-tools');
+        parent.appendChild(div);
+    });
+    return div;
+}
+
+function setupTools() {
+    const avail = document.getElementById('available-tools');
+    availableTools.forEach(t => avail.appendChild(makeTool(t)));
+
+    const areas = [document.getElementById('available-tools'), document.getElementById('tools')];
+    areas.forEach(area => {
+        area.addEventListener('dragover', e => e.preventDefault());
+        area.addEventListener('drop', e => {
+            e.preventDefault();
+            const name = e.dataTransfer.getData('text/plain');
+            const tool = [...document.querySelectorAll('.tool')].find(d => d.textContent === name);
+            area.appendChild(tool);
+        });
+    });
+}
+
+let ws;
+function connect() {
+    ws = new WebSocket(`ws://${location.host}/ws`);
+    ws.onmessage = event => {
+        const history = document.getElementById('history');
+        history.value += event.data;
+        history.scrollTop = history.scrollHeight;
+    };
+}
+
+function sendMessage() {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    const systemPrompt = document.getElementById('system-prompt').value;
+    const extraEnabled = document.getElementById('enable-extra').checked;
+    const extraPrompt = extraEnabled ? document.getElementById('extra-prompt').value : '';
+    const userMsg = document.getElementById('user-msg').value;
+    const tools = [...document.getElementById('tools').children].map(d => d.textContent);
+    const payload = {systemPrompt, extraPrompt, userMsg, tools};
+    ws.send(JSON.stringify(payload));
+    document.getElementById('user-msg').value = '';
+    const history = document.getElementById('history');
+    history.value += `\nUser: ${userMsg}\n`;
+}
+
+window.addEventListener('load', () => {
+    setupTools();
+    connect();
+    document.getElementById('send-btn').addEventListener('click', sendMessage);
+});


### PR DESCRIPTION
## Summary
- add demo FastAPI backend with WebSocket streaming
- create simple HTML/JS UI to chat with backend and move tools around
- document setup and execution steps
- list minimal dependencies

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_685ade6cb5588326bd833b8df682a7a9