### PR TITLE
Enhance demo UI layout and backend

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
+
+TOOLS = ["calculator", "search", "wikipedia", "weather"]
 
 with open("static/index.html", "r") as f:
     index_html = f.read()
@@ -13,6 +15,11 @@ with open("static/index.html", "r") as f:
 @app.get("/")
 async def get_index():
     return HTMLResponse(index_html)
+
+
+@app.get("/tools")
+async def get_tools():
+    return JSONResponse({"tools": TOOLS})
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
@@ -22,11 +29,26 @@ async def websocket_endpoint(websocket: WebSocket):
             data = await websocket.receive_text()
             payload = json.loads(data)
             user_msg = payload.get("userMsg", "")
-            # Simple streaming: echo each word with delay
-            response = f"Agent: You said '{user_msg}'. Using tools {payload.get('tools', [])}\n"
-            for word in response.split():
-                await websocket.send_text(word + " ")
-                await asyncio.sleep(0.3)
-            await websocket.send_text("\n")
+            tools = ", ".join(payload.get("tools", [])) or "none"
+            system_prompt = payload.get("systemPrompt", "")
+            extra_prompt = payload.get("extraPrompt", "")
+            lines = [
+                f"Agent received: '{user_msg}'",
+                f"System prompt: {system_prompt}",
+                f"Extra prompt: {extra_prompt}",
+                f"Tools: {tools}",
+                "Generating meaningless text...",
+            ]
+            for line in lines:
+                for word in line.split():
+                    await websocket.send_text(word + " ")
+                    await asyncio.sleep(0.2)
+                await websocket.send_text("\n")
+            for _ in range(3):
+                dummy = "lorem ipsum dolor sit amet consectetur".split()
+                for word in dummy:
+                    await websocket.send_text(word + " ")
+                    await asyncio.sleep(0.2)
+                await websocket.send_text("\n")
     except WebSocketDisconnect:
         pass

--- a/static/index.html
+++ b/static/index.html
@@ -6,28 +6,36 @@
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         textarea { width: 100%; box-sizing: border-box; margin-bottom: 10px; }
-        #history { height: 300px; }
+        #container { display: flex; gap: 20px; }
+        #left { width: 30%; }
+        #right { flex: 1; display: flex; flex-direction: column; }
+        #history { height: 300px; flex: 1; }
         #tools, #available-tools { display: flex; flex-wrap: wrap; gap: 5px; border: 1px solid #ccc; padding: 10px; min-height: 50px; }
         .tool { padding: 5px 10px; background: #eee; border: 1px solid #ccc; cursor: pointer; user-select: none; }
+        #extra-prompt.inactive { opacity: 0.5; background: #f5f5f5; }
     </style>
 </head>
 <body>
 <h1>Agent Demo</h1>
-<label>System Prompt:</label>
-<textarea id="system-prompt"></textarea>
-<label><input type="checkbox" id="enable-extra" checked> Additional Prompt:</label>
-<textarea id="extra-prompt"></textarea>
-<label>Chat History:</label>
-<textarea id="history" readonly></textarea>
-<label>User Message:</label>
-<input type="text" id="user-msg" style="width:100%;"/>
-
-<h3>Available Tools</h3>
-<div id="available-tools"></div>
-<h3>Selected Tools</h3>
-<div id="tools"></div>
-
-<button id="send-btn">Send</button>
+<div id="container">
+    <div id="left">
+        <label>System Prompt:</label>
+        <textarea id="system-prompt"></textarea>
+        <label><input type="checkbox" id="enable-extra" checked> Additional Prompt:</label>
+        <textarea id="extra-prompt"></textarea>
+        <h3>Available Tools</h3>
+        <div id="available-tools"></div>
+        <h3>Selected Tools</h3>
+        <div id="tools"></div>
+    </div>
+    <div id="right">
+        <label>Chat History:</label>
+        <textarea id="history" readonly></textarea>
+        <label>User Message:</label>
+        <input type="text" id="user-msg" style="width:100%;"/>
+        <button id="send-btn">Send</button>
+    </div>
+</div>
 
 <script src="script.js"></script>
 </body>

--- a/static/script.js
+++ b/static/script.js
@@ -1,4 +1,4 @@
-const availableTools = ["calculator", "search", "wikipedia", "weather"]; // sample tools
+let availableTools = [];
 
 function makeTool(name) {
     const div = document.createElement('div');
@@ -17,6 +17,7 @@ function makeTool(name) {
 
 function setupTools() {
     const avail = document.getElementById('available-tools');
+    avail.innerHTML = '';
     availableTools.forEach(t => avail.appendChild(makeTool(t)));
 
     const areas = [document.getElementById('available-tools'), document.getElementById('tools')];
@@ -29,6 +30,13 @@ function setupTools() {
             area.appendChild(tool);
         });
     });
+}
+
+async function fetchTools() {
+    const resp = await fetch('/tools');
+    const data = await resp.json();
+    availableTools = data.tools;
+    setupTools();
 }
 
 let ws;
@@ -55,8 +63,22 @@ function sendMessage() {
     history.value += `\nUser: ${userMsg}\n`;
 }
 
+function toggleExtraPrompt() {
+    const cb = document.getElementById('enable-extra');
+    const area = document.getElementById('extra-prompt');
+    if (cb.checked) {
+        area.classList.remove('inactive');
+        area.disabled = false;
+    } else {
+        area.classList.add('inactive');
+        area.disabled = true;
+    }
+}
+
 window.addEventListener('load', () => {
-    setupTools();
+    fetchTools();
     connect();
+    toggleExtraPrompt();
     document.getElementById('send-btn').addEventListener('click', sendMessage);
+    document.getElementById('enable-extra').addEventListener('change', toggleExtraPrompt);
 });


### PR DESCRIPTION
## Summary
- reorganize frontend layout with left prompt/tools column and right chat column
- style extra prompt when disabled and fetch tools list from backend
- implement tool fetching and extra prompt toggling in JS
- extend backend to serve tool list and stream demo responses using prompts and tools

## Testing
- `python -m py_compile server.py`
- `node -e "require('fs').readFileSync('static/script.js')"`

------
https://chatgpt.com/codex/tasks/task_e_685af8cfbee4832683dc1d5b6ec39dde