### PR TITLE
Enable markdown in chat history

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -49,6 +49,13 @@
         #history {
             height: 300px;
             flex: 1;
+            overflow-y: auto;
+            background: #40414f;
+            color: #e6e6e6;
+            border: 1px solid #555;
+            padding: 10px;
+            border-radius: 4px;
+            white-space: pre-wrap;
         }
 
         #user-input {
@@ -180,7 +187,7 @@
     </div>
     <div id="right">
         <label>Чат:</label>
-        <textarea id="history" readonly></textarea>
+        <div id="history"></div>
         <label>Сообщение:</label>
         <div id="user-input">
             <input type="text" id="user-msg" />
@@ -189,6 +196,7 @@
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="/static/script.js"></script>
 </body>
 </html>

--- a/static/script.js
+++ b/static/script.js
@@ -46,6 +46,7 @@ async function fetchTools() {
 
 let ws;
 let pendingQuestion = false;
+let historyMarkdown = '';
 function connect() {
     ws = new WebSocket(`ws://${location.host}/ws`);
     ws.onmessage = event => {
@@ -53,13 +54,15 @@ function connect() {
         try {
             const data = JSON.parse(event.data);
             if (data.type === 'question') {
-                history.value += `\n[Agent asks]: ${data.text}\n`;
+                historyMarkdown += `\n**[Agent asks]:** ${data.text}\n`;
+                history.innerHTML = marked.parse(historyMarkdown);
                 history.scrollTop = history.scrollHeight;
                 pendingQuestion = true;
                 return;
             }
         } catch (e) {}
-        history.value += event.data;
+        historyMarkdown += event.data;
+        history.innerHTML = marked.parse(historyMarkdown);
         history.scrollTop = history.scrollHeight;
     };
 }
@@ -75,7 +78,8 @@ function sendMessage() {
     ws.send(JSON.stringify(payload));
     document.getElementById('user-msg').value = '';
     const history = document.getElementById('history');
-    history.value += `\nUser: ${userMsg}\n`;
+    historyMarkdown += `\n**User:** ${userMsg}\n`;
+    history.innerHTML = marked.parse(historyMarkdown);
     pendingQuestion = false;
 }
 


### PR DESCRIPTION
## Summary
- style chat history panel to display rich formatted text
- switch chat history from a `<textarea>` to a `<div>` and load `marked.js`
- render incoming messages as Markdown in script.js

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bde79d934832692f52ac218edcd2d