### PR TITLE
Support multi-user sessions

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -3,15 +3,20 @@ from state import AgentState
 from nodes import reflect_node, use_tool_node, should_use_tool
 from functools import partial
 
-def get_graph(model):
+def get_graph(model, tools_by_name=None):
+    if tools_by_name is None:
+        from nodes import tools_by_name as default_tools
+        tools_by_name = default_tools
+
     workflow = StateGraph(AgentState)
 
     reflect_with_tools = partial(reflect_node, model=model)
+    use_tool_with_dict = partial(use_tool_node, tools_by_name=tools_by_name)
 
     # Step 1: reflect (plan & choose action)
     workflow.add_node("reflect", reflect_with_tools)
     # Step 2: execute (call the chosen tool)
-    workflow.add_node("use_tool", use_tool_node)
+    workflow.add_node("use_tool", use_tool_with_dict)
 
     # Start by reflecting
     workflow.set_entry_point("reflect")

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ with open("static/index.html", "r") as f:
     index_html = f.read()
 
 
-def create_agent():
+def create_agent(tools_by_name=None):
     api_key = os.getenv("GIGACHAT_API_KEY")
     model = GigaChat(
         credentials=api_key,
@@ -60,7 +60,7 @@ def create_agent():
     # Bind exactly the same tools that are advertised via the `/tools` endpoint
     tools_list = [tool for tool, _ in TOOL_DEFS]
     model = model.bind_tools(tools_list)
-    return get_graph(model)
+    return get_graph(model, tools_by_name=tools_by_name)
 
 
 @app.get("/")
@@ -76,9 +76,6 @@ async def get_tools():
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
-    graph = create_agent()
-    conversation = {"messages": []}
-    config = {"configurable": {"prompt": None}}
 
     loop = asyncio.get_running_loop()
     answer_queue: asyncio.Queue[str] = asyncio.Queue()
@@ -100,7 +97,12 @@ async def websocket_endpoint(websocket: WebSocket):
             return {"answer": answer}
 
     import nodes
-    nodes.tools_by_name["question_user_tool"] = QuestionTool()
+    tools_dict = nodes.tools_by_name.copy()
+    tools_dict["question_user_tool"] = QuestionTool()
+
+    graph = create_agent(tools_by_name=tools_dict)
+    conversation = {"messages": []}
+    config = {"configurable": {"prompt": None}}
 
     def run_graph(user_input: str):
         conversation["messages"].append(HumanMessage(content=user_input))

--- a/nodes.py
+++ b/nodes.py
@@ -6,7 +6,18 @@ from tools import provide_answer_tool, question_user_tool, search_rag_tool, read
 from prompts import create_system_prompt, get_react_instructions
 
 # Map name → tool
-tools_by_name = {tool.name: tool for tool in [provide_answer_tool, question_user_tool, search_rag_tool, read_webpage_tool, current_date_tool, calculator_tool, search_tool]}
+tools_by_name = {
+    tool.name: tool
+    for tool in [
+        provide_answer_tool,
+        question_user_tool,
+        search_rag_tool,
+        read_webpage_tool,
+        current_date_tool,
+        calculator_tool,
+        search_tool,
+    ]
+}
 
 def reflect_node(state: AgentState, config: RunnableConfig, model):
     """1) Reflect, plan & choose one tool call."""
@@ -27,7 +38,7 @@ def reflect_node(state: AgentState, config: RunnableConfig, model):
 
     return {"messages": [response]}
 
-def use_tool_node(state: AgentState):
+def use_tool_node(state: AgentState, tools_by_name):
     """2) Execute the tool call chosen in reflect_node."""
     outputs = []
     last = state["messages"][-1]


### PR DESCRIPTION
## Summary
- refactor `use_tool_node` to accept injected tools dictionary
- allow injecting custom tools per user when building the graph
- create per-session QuestionTool instance in WebSocket endpoint

## Testing
- `python -m py_compile main.py nodes.py graph.py chat_demo.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfab072e88326b5ecd093a0f11bd7