### PR TITLE
Fix overflow in chat history

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -56,6 +56,8 @@
             padding: 10px;
             border-radius: 4px;
             white-space: pre-wrap;
+            word-break: break-word;
+            overflow-wrap: anywhere;
         }
 
         #user-input {


### PR DESCRIPTION
## Summary
- prevent chat history panel from expanding width by breaking long words

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bff5416fc8326bcfd181d3e2a2371