### PR TITLE
Add retry button for websocket

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -87,6 +87,16 @@
             cursor: pointer;
         }
 
+        #reset-btn {
+            height: 40px;
+            background: #2f74c0;
+            border: none;
+            color: #fff;
+            padding: 0 15px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
         #retry-btn {
             height: 40px;
             background: #2f74c0;
@@ -95,6 +105,11 @@
             padding: 0 15px;
             border-radius: 4px;
             cursor: pointer;
+        }
+
+        #retry-btn:disabled {
+            opacity: 0.5;
+            cursor: default;
         }
 
         #tools,
@@ -146,7 +161,7 @@
 <body>
 <div id="header">
     <h1>Демо агента</h1>
-    <button id="retry-btn">Переподключиться</button>
+    <button id="reset-btn">Переподключиться</button>
 </div>
 <div id="container">
     <div id="left">
@@ -213,6 +228,7 @@
         <div id="user-input">
             <input type="text" id="user-msg" />
             <button id="send-btn">Отправить</button>
+            <button id="retry-btn" disabled>Повторить</button>
         </div>
     </div>
 </div>

--- a/static/script.js
+++ b/static/script.js
@@ -47,9 +47,14 @@ async function fetchTools() {
 let ws;
 let pendingQuestion = false;
 let historyMarkdown = '';
+let resetBtn;
 let retryBtn;
-function connect() {
+let lastPayload = null;
+function connect(onOpen) {
     ws = new WebSocket(`ws://${location.host}/ws`);
+    if (onOpen) {
+        ws.addEventListener('open', onOpen, { once: true });
+    }
     ws.onmessage = event => {
         const history = document.getElementById('history');
         try {
@@ -68,9 +73,10 @@ function connect() {
     };
     ws.onclose = () => {
         const history = document.getElementById('history');
-        historyMarkdown += '\n**[System]:** Соединение прервано. Нажмите "Переподключиться".\n';
+        historyMarkdown += '\n**[System]:** Соединение прервано. Нажмите \"Повторить\".\n';
         history.innerHTML = marked.parse(historyMarkdown);
         history.scrollTop = history.scrollHeight;
+        retryBtn.disabled = false;
     };
 }
 
@@ -81,13 +87,14 @@ function sendMessage() {
     const extraPrompt = extraEnabled ? document.getElementById('extra-prompt').value : '';
     const userMsg = document.getElementById('user-msg').value;
     const tools = [...document.getElementById('tools').children].map(d => d.dataset.name);
-    const payload = {systemPrompt, extraPrompt, userMsg, tools};
-    ws.send(JSON.stringify(payload));
+    lastPayload = {systemPrompt, extraPrompt, userMsg, tools};
+    ws.send(JSON.stringify(lastPayload));
     document.getElementById('user-msg').value = '';
     const history = document.getElementById('history');
     historyMarkdown += `\n**User:** ${userMsg}\n`;
     history.innerHTML = marked.parse(historyMarkdown);
     pendingQuestion = false;
+    retryBtn.disabled = true;
 }
 
 function toggleExtraPrompt() {
@@ -116,12 +123,30 @@ function toggleExtraPrompt() {
         document.getElementById('enable-extra').addEventListener('change', toggleExtraPrompt);
         retryBtn = document.getElementById('retry-btn');
         retryBtn.addEventListener('click', () => {
+            if (!lastPayload) return;
+            const sendPayload = () => {
+                ws.send(JSON.stringify(lastPayload));
+                const history = document.getElementById('history');
+                historyMarkdown += `\n**User (повтор):** ${lastPayload.userMsg}\n`;
+                history.innerHTML = marked.parse(historyMarkdown);
+                retryBtn.disabled = true;
+            };
+            if (!ws || ws.readyState !== WebSocket.OPEN) {
+                connect(() => sendPayload());
+            } else {
+                sendPayload();
+            }
+        });
+        resetBtn = document.getElementById('reset-btn');
+        resetBtn.addEventListener('click', () => {
             if (ws) {
                 ws.onclose = null;
                 ws.close();
             }
             historyMarkdown = '';
             document.getElementById('history').innerHTML = '';
+            lastPayload = null;
+            retryBtn.disabled = true;
             connect();
         });
     });


### PR DESCRIPTION
## Summary
- add a retry button to the chat UI
- disable/enable the button depending on WebSocket state
- show a message when the connection is lost

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685c00b2cae483268a7de47d670966cf