### PR TITLE
Improve chat history layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -45,6 +45,7 @@
             display: flex;
             flex-direction: column;
             min-height: 0;
+            min-width: 0;
         }
 
         #history {
@@ -52,6 +53,7 @@
             overflow-y: auto;
             overflow-x: hidden;
             min-height: 0;
+            min-width: 0;
             background: #40414f;
             color: #e6e6e6;
             border: 1px solid #555;
@@ -66,6 +68,7 @@
         #history code {
             white-space: pre-wrap;
             word-break: break-word;
+            overflow-wrap: anywhere;
         }
 
         #user-input {


### PR DESCRIPTION
## Summary
- keep chat area fixed size
- wrap code blocks to avoid horizontal overflow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c1189382c8326afa8d3eef9ed9b8b