### PR TITLE
Fix conversation history mismatch for function calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,7 @@ async def websocket_endpoint(websocket: WebSocket):
             msg = step["messages"][-1]
             if msg in conversation["messages"]:
                 continue
+            conversation["messages"].append(msg)
             if getattr(msg, "name", "") in ["provide_answer_tool", "question_user_tool"]:
                 continue
             if isinstance(msg, AIMessage):
@@ -126,7 +127,6 @@ async def websocket_endpoint(websocket: WebSocket):
                     websocket.send_text(getattr(msg, "content", str(msg)) + "\n"),
                     loop,
                 )
-            conversation["messages"].append(msg)
 
     try:
         while True:


### PR DESCRIPTION
## Summary
- append tool results to conversation state before filtering out special messages

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685c3833d8148326972839c152f02fc5