### PR TITLE
Fix dynamic prompt and tool selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,13 @@ async def websocket_endpoint(websocket: WebSocket):
             data = await websocket.receive_text()
             payload = json.loads(data)
             user_msg = payload.get("userMsg", "")
-            tool_names = payload.get("tools") or [t[0].name for t in TOOL_DEFS]
+            tool_names = payload.get("tools", None)
+            if tool_names is None:
+                tool_names = [t[0].name for t in TOOL_DEFS]
+
+            system_prompt = payload.get("systemPrompt", "")
+            extra_prompt = payload.get("extraPrompt", "")
+            config["configurable"]["prompt"] = f"{system_prompt}{extra_prompt}"
             if waiting["status"]:
                 await answer_queue.put(user_msg)
                 continue


### PR DESCRIPTION
## Summary
- ensure server handles empty tool list properly
- update websocket handler to combine system and extra prompts

## Testing
- `python -m py_compile main.py nodes.py tools.py graph.py server.py prompts.py rag_module.py rag.py model.py lesson.py chat_demo.py state.py`

------
https://chatgpt.com/codex/tasks/task_e_685c3e717efc83268736a5681c83f0f6