### PR TITLE
Load env vars and rename Tavily tool

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,10 @@ import os
 import re
 import time
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles

--- a/tools.py
+++ b/tools.py
@@ -94,7 +94,5 @@ from langchain_tavily import TavilySearch
 import smtplib
 from email.mime.text import MIMEText
 
-if not os.environ.get("TAVILY_API_KEY"):
-    os.environ["TAVILY_API_KEY"] = "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"
-    
 search_tool = TavilySearch(max_results=3)
+search_tool.name = "search_tool"


### PR DESCRIPTION
## Summary
- load environment variables from `.env` in `main.py`
- rename Tavily search tool to `search_tool` and remove hardcoded API key

## Testing
- `python -m py_compile tools.py main.py nodes.py rag.py rag_module.py graph.py model.py chat_demo.py lesson.py server.py prompts.py state.py`

------
https://chatgpt.com/codex/tasks/task_e_685c5b1f73e48326a9d2c189a895a012