### PR TITLE
Add required tool flag and enforce in UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,21 +23,24 @@ from tools import (
 
 # Tool objects paired with human readable labels. This single source is used
 # both for binding tools to the model and for populating the `/tools` endpoint
-# so that the UI and backend stay in sync.
+# so that the UI and backend stay in sync.  Each entry may also specify that the
+# tool is required, meaning it must always be enabled in the UI.
 TOOL_DEFS = [
-    (provide_answer_tool, "ответ пользователю"),
-    (question_user_tool, "уточнить у пользователя"),
-    (search_rag_tool, "поиск в документации"),
-    (search_tool, "поиск в интернете"),
-    (read_webpage_tool, "просмотр страниц"),
-    (current_date_tool, "текущая дата"),
-    (calculator_tool, "калькулятор"),
+    {"tool": provide_answer_tool, "label": "ответ пользователю", "required": True},
+    {"tool": question_user_tool, "label": "уточнить у пользователя", "required": False},
+    {"tool": search_rag_tool, "label": "поиск в документации", "required": False},
+    {"tool": search_tool, "label": "поиск в интернете", "required": False},
+    {"tool": read_webpage_tool, "label": "просмотр страниц", "required": False},
+    {"tool": current_date_tool, "label": "текущая дата", "required": False},
+    {"tool": calculator_tool, "label": "калькулятор", "required": False},
 ]
 
 # List of tools for the UI. Each entry contains the tool name (which must match
-# the bound tool) and a user friendly label.
+# the bound tool), a user friendly label and the `required` flag so that the UI
+# can enforce it.
 TOOLS = [
-    {"name": tool.name, "label": label} for tool, label in TOOL_DEFS
+    {"name": entry["tool"].name, "label": entry["label"], "required": entry["required"]}
+    for entry in TOOL_DEFS
 ]
 
 app = FastAPI()
@@ -58,7 +61,7 @@ def create_agent(tools_by_name=None):
         profanity_check=False,
     )
     # Bind exactly the same tools that are advertised via the `/tools` endpoint
-    tools_list = [tool for tool, _ in TOOL_DEFS]
+    tools_list = [entry["tool"] for entry in TOOL_DEFS]
     model = model.bind_tools(tools_list)
     return get_graph(model, tools_by_name=tools_by_name)
 

--- a/static/index.html
+++ b/static/index.html
@@ -107,6 +107,11 @@
             color: #e6e6e6;
         }
 
+        .tool.required {
+            background: #5b5b5b;
+            cursor: default;
+        }
+
         .tool:hover {
             background: #4b4b4b;
         }

--- a/static/script.js
+++ b/static/script.js
@@ -5,23 +5,39 @@ function makeTool(tool) {
     div.className = 'tool';
     div.textContent = tool.label;
     div.dataset.name = tool.name;
-    div.draggable = true;
-    div.addEventListener('dragstart', e => {
-        e.dataTransfer.setData('text/plain', tool.name);
-    });
-    div.addEventListener('click', () => {
-        const parent = div.parentElement.id === 'available-tools'
-            ? document.getElementById('tools')
-            : document.getElementById('available-tools');
-        parent.appendChild(div);
-    });
+    div.dataset.required = tool.required ? 'true' : 'false';
+
+    if (!tool.required) {
+        div.draggable = true;
+        div.addEventListener('dragstart', e => {
+            e.dataTransfer.setData('text/plain', tool.name);
+        });
+        div.addEventListener('click', () => {
+            const parent = div.parentElement.id === 'available-tools'
+                ? document.getElementById('tools')
+                : document.getElementById('available-tools');
+            parent.appendChild(div);
+        });
+    } else {
+        div.classList.add('required');
+    }
     return div;
 }
 
 function setupTools() {
     const avail = document.getElementById('available-tools');
+    const active = document.getElementById('tools');
     avail.innerHTML = '';
-    availableTools.forEach(t => avail.appendChild(makeTool(t)));
+    active.innerHTML = '';
+
+    availableTools.forEach(t => {
+        const elem = makeTool(t);
+        if (t.required) {
+            active.appendChild(elem);
+        } else {
+            avail.appendChild(elem);
+        }
+    });
 
     const areas = [document.getElementById('available-tools'), document.getElementById('tools')];
     areas.forEach(area => {
@@ -30,7 +46,7 @@ function setupTools() {
             e.preventDefault();
             const name = e.dataTransfer.getData('text/plain');
             const tool = [...document.querySelectorAll('.tool')].find(d => d.dataset.name === name);
-            if (tool) {
+            if (tool && tool.dataset.required !== 'true') {
                 area.appendChild(tool);
             }
         });


### PR DESCRIPTION
## Summary
- support `required` flag for tools in `main.py`
- expose flag via `/tools` endpoint
- ensure required tools are always active in UI and cannot be removed
- style required tools differently

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685cda03d4688326a3aec6b7e342f01f