### PR TITLE
Add required tool selection logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,9 +41,15 @@ TOOL_DEFS = [
 ]
 
 # List of tools for the UI. Each entry contains the tool name (which must match
-# the bound tool) and a user friendly label.
+# the bound tool), a user friendly label and whether it is required.
+REQUIRED_TOOL_NAMES = {provide_answer_tool.name}
 TOOLS = [
-    {"name": tool.name, "label": label} for tool, label in TOOL_DEFS
+    {
+        "name": tool.name,
+        "label": label,
+        "required": tool.name in REQUIRED_TOOL_NAMES,
+    }
+    for tool, label in TOOL_DEFS
 ]
 
 app = FastAPI()

--- a/static/script.js
+++ b/static/script.js
@@ -1,10 +1,11 @@
-let availableTools = [];
+let allTools = [];
 
 function makeTool(tool) {
     const div = document.createElement('div');
     div.className = 'tool';
     div.textContent = tool.label;
     div.dataset.name = tool.name;
+    div.dataset.required = tool.required ? 'true' : 'false';
     div.draggable = true;
     div.addEventListener('dragstart', e => {
         e.dataTransfer.setData('text/plain', tool.name);
@@ -13,6 +14,9 @@ function makeTool(tool) {
         const parent = div.parentElement.id === 'available-tools'
             ? document.getElementById('tools')
             : document.getElementById('available-tools');
+        if (div.dataset.required === 'true' && parent.id === 'available-tools') {
+            return;
+        }
         parent.appendChild(div);
     });
     return div;
@@ -20,8 +24,17 @@ function makeTool(tool) {
 
 function setupTools() {
     const avail = document.getElementById('available-tools');
+    const selected = document.getElementById('tools');
     avail.innerHTML = '';
-    availableTools.forEach(t => avail.appendChild(makeTool(t)));
+    selected.innerHTML = '';
+    allTools.forEach(t => {
+        const div = makeTool(t);
+        if (t.required) {
+            selected.appendChild(div);
+        } else {
+            avail.appendChild(div);
+        }
+    });
 
     const areas = [document.getElementById('available-tools'), document.getElementById('tools')];
     areas.forEach(area => {
@@ -31,6 +44,9 @@ function setupTools() {
             const name = e.dataTransfer.getData('text/plain');
             const tool = [...document.querySelectorAll('.tool')].find(d => d.dataset.name === name);
             if (tool) {
+                if (tool.dataset.required === 'true' && area.id === 'available-tools') {
+                    return;
+                }
                 area.appendChild(tool);
             }
         });
@@ -40,7 +56,7 @@ function setupTools() {
 async function fetchTools() {
     const resp = await fetch('/tools');
     const data = await resp.json();
-    availableTools = data.tools;
+    allTools = data.tools;
     setupTools();
 }
 


### PR DESCRIPTION
## Summary
- add a `required` property for tools in `main.py`
- place required tools on the selected list and prevent removing them on the UI

## Testing
- `pytest -q`
- `python -m py_compile main.py`
- `python -m py_compile tools.py`


------
https://chatgpt.com/codex/tasks/task_e_685ce79829a48326abcc88b9e3911e0c