### PR TITLE
Switch to ToolNode for tool execution

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -1,22 +1,22 @@
 from langgraph.graph import StateGraph, END
+from langgraph.prebuilt import ToolNode
 from state import AgentState
-from nodes import reflect_node, use_tool_node, should_use_tool
+from nodes import reflect_node, should_use_tool, tools as default_tools
 from functools import partial
 
-def get_graph(model, tools_by_name=None):
-    if tools_by_name is None:
-        from nodes import tools_by_name as default_tools
-        tools_by_name = default_tools
+def get_graph(model, tools=None):
+    if tools is None:
+        tools = default_tools
 
     workflow = StateGraph(AgentState)
 
     reflect_with_tools = partial(reflect_node, model=model)
-    use_tool_with_dict = partial(use_tool_node, tools_by_name=tools_by_name)
+    tool_node = ToolNode(tools)
 
     # Step 1: reflect (plan & choose action)
     workflow.add_node("reflect", reflect_with_tools)
     # Step 2: execute (call the chosen tool)
-    workflow.add_node("use_tool", use_tool_with_dict)
+    workflow.add_node("use_tool", tool_node)
 
     # Start by reflecting
     workflow.set_entry_point("reflect")
@@ -40,6 +40,6 @@ if __name__ == "__main__":
     import io
     from PIL import Image
 
-    imageStream = io.BytesIO(get_graph().get_graph().draw_mermaid_png())
+    imageStream = io.BytesIO(get_graph(model=None).get_graph().draw_mermaid_png())
     imageFile = Image.open(imageStream)
     imageFile.save('graph.jpg')

--- a/lesson.py
+++ b/lesson.py
@@ -37,7 +37,7 @@ print("Tool names handed to graph:", [t.name for t in tools_list])
 
 model = model.bind_tools(tools_list)
 
-graph = get_graph(model)
+graph = get_graph(model, tools_list)
 
 prompt = None
 

--- a/nodes.py
+++ b/nodes.py
@@ -1,5 +1,4 @@
-import json
-from langchain_core.messages import ToolMessage, SystemMessage, HumanMessage
+from langchain_core.messages import SystemMessage
 from langchain_core.runnables import RunnableConfig
 from state import AgentState
 from tools import (
@@ -12,18 +11,15 @@ from tools import (
 )
 from prompts import create_system_prompt, get_react_instructions
 
-# Map name → tool
-tools_by_name = {
-    tool.name: tool
-    for tool in [
-        response_tool,
-        read_webpage_tool,
-        current_date_tool,
-        calculator_tool,
-        send_email_tool,
-        search_tool,
-    ]
-}
+# List of available tools
+tools = [
+    response_tool,
+    read_webpage_tool,
+    current_date_tool,
+    calculator_tool,
+    send_email_tool,
+    search_tool,
+]
 
 def reflect_node(state: AgentState, config: RunnableConfig, model):
     """1) Reflect, plan & choose one tool call."""
@@ -43,22 +39,6 @@ def reflect_node(state: AgentState, config: RunnableConfig, model):
     response = model.invoke([system] + list(state["messages"]), config)
 
     return {"messages": [response]}
-
-def use_tool_node(state: AgentState, tools_by_name):
-    """2) Execute the tool call chosen in reflect_node."""
-    outputs = []
-    last = state["messages"][-1]
-
-    for call in last.tool_calls:
-        result = tools_by_name[call["name"]].invoke(call["args"])
-        outputs.append(
-            ToolMessage(
-                content=json.dumps(result, ensure_ascii=False),
-                name=call["name"],
-                tool_call_id=call["id"],
-            )
-        )
-    return {"messages": outputs}
 
 def should_use_tool(state: AgentState):
     """If the last LLM output included a tool call, go to execute; otherwise end."""


### PR DESCRIPTION
## Summary
- Replace custom tool execution with langgraph's ToolNode
- Pass tool list to graph builder and lesson script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c2d2f13e48326907201a58045c479