### PR TITLE
Add VS Code debug configuration for FastAPI service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 test*
 .env
-.vscode
+.vscode/*
+!.vscode/launch.json
 rag_sources
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "FastAPI: Uvicorn",
+      "type": "python",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": [
+        "main:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000",
+        "--reload"
+      ],
+      "jinja": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- allow tracking of `.vscode/launch.json`
- add VS Code debug configuration to launch `uvicorn main:app`

## Testing
- `pytest`
- `python -m uvicorn main:app --port 8000` *(fails: Unrecognized model intfloat/multilingual-e5-large)*


------
https://chatgpt.com/codex/tasks/task_e_689ec16a44d48326a614e339840be848