### PR TITLE
Start MCP server for LangChain tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Agent Demo
+
+This project demonstrates a simple agent with several LangChain tools.
+
+## MCP Server
+
+The module `mcp_server.py` exposes every tool defined in `tools.py` through
+a Model Context Protocol (MCP) server. The server starts in a background
+thread as soon as the module is imported, allowing external MCP-capable
+clients to discover and invoke these resources (`response_tool`,
+`read_webpage_tool`, `current_date_tool`, `calculator_tool`,
+`send_email_tool`, and `search_tool`).
+
+To launch the server manually run:
+
+```bash
+python mcp_server.py
+```
+
+Running `lesson.py` imports `mcp_server`, so the MCP server starts
+automatically during initialization.
+

--- a/lesson.py
+++ b/lesson.py
@@ -3,6 +3,8 @@ from langchain_core.messages import HumanMessage, AIMessage
 from dotenv import load_dotenv
 load_dotenv()
 
+import mcp_server  # start MCP server for external clients
+
 import json
 from colorama import init, Fore, Style
 from graph import get_graph

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,49 @@
+"""MCP server that exposes all tools defined in tools.py.
+
+The server uses the `mcp` package to register each tool as a resource.
+It starts automatically when this module is imported so that external
+MCP-capable clients can discover the available tools.
+"""
+import threading
+
+from tools import (
+    response_tool,
+    read_webpage_tool,
+    current_date_tool,
+    calculator_tool,
+    send_email_tool,
+    search_tool,
+)
+
+try:
+    from mcp.server.fastapi import FastAPIServer
+except ImportError:  # pragma: no cover - optional dependency for tests
+    FastAPIServer = None  # type: ignore
+
+
+def _run_server() -> None:
+    """Create and run the MCP server in the current thread."""
+    if FastAPIServer is None:
+        print("MCP package not installed. MCP server not started.")
+        return
+
+    server = FastAPIServer("agent-demo")
+
+    # Register every tool defined in tools.py so clients can invoke them.
+    for tool in [
+        response_tool,
+        read_webpage_tool,
+        current_date_tool,
+        calculator_tool,
+        send_email_tool,
+        search_tool,
+    ]:
+        server.register_tool(tool)
+
+    # Start serving (blocking call).
+    server.run()
+
+
+# Launch the server in a background thread during module import so that
+# it is available as soon as the application starts.
+threading.Thread(target=_run_server, daemon=True).start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ Requests==2.32.4
 torch==2.6.0
 transformers==4.50.0
 uvicorn
+mcp


### PR DESCRIPTION
## Summary
- expose all tools in `tools.py` through a Model Context Protocol server
- ensure the server starts during app initialization
- document MCP server usage in the README

## Testing
- `python -m py_compile tools.py mcp_server.py lesson.py`
- `python mcp_server.py` *(fails: ModuleNotFoundError: No module named 'langchain_core')*
- `pip install langchain_core` *(fails: Could not find a version that satisfies the requirement langchain_core)*

------
https://chatgpt.com/codex/tasks/task_e_68baca019774832690777a026fbd11e6