### PR TITLE
handle structured tools in MCP server

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,20 +1,15 @@
 """MCP server that exposes all tools defined in tools.py.
 
-The server uses the `mcp` package to register each tool as a resource.
-It starts automatically when this module is imported so that external
-MCP-capable clients can discover the available tools.
+The server uses the `mcp` package to register each tool as a resource. It
+starts automatically when this module is imported so that external MCP-capable
+clients can discover the available tools.
 """
+
 import threading
+
 from mcp.server.fastmcp import FastMCP
 
-from tools import (
-    response_tool,
-    read_webpage_tool,
-    current_date_tool,
-    calculator_tool,
-    send_email_tool,
-    search_tool,
-)
+from tools import register_tools
 
 
 def _run_server() -> None:
@@ -25,17 +20,8 @@ def _run_server() -> None:
 
     server = FastMCP("agent-demo")
 
-    # Register every tool defined in tools.py so clients can invoke them.
-    for tool in [
-        response_tool,
-        read_webpage_tool,
-        current_date_tool,
-        calculator_tool,
-        send_email_tool,
-        search_tool,
-    ]:
-        # `FastMCP.tool()` returns a decorator that registers the function.
-        server.tool()(tool)
+    # Register every tool using the decorator provided by the server.
+    register_tools(server.tool)
 
     # Start serving (blocking call).
     server.run(transport="stdio")

--- a/tools.py
+++ b/tools.py
@@ -1,62 +1,74 @@
-from langchain_core.tools import tool
-from typing import List, Annotated
-from bs4 import BeautifulSoup
+"""Tool definitions registerable with an MCP server.
 
-@tool
-def response_tool(response: Annotated[str, "сообщение для пользователя"]) -> dict:
-    """Отправить сообщение пользователю. Это может быть вопрос или полный и развернутый ответ"""
-    return {"answer": response}
+The `register_tools` function accepts a decorator factory (such as
+`server.tool`) and applies it to each tool defined here so that they are
+registered with the MCP server without relying on LangChain's `@tool`
+decorator.
+"""
 
-import requests
+from __future__ import annotations
 
-# ─── Read & Extract Webpage Text ───
-@tool
-def read_webpage_tool(url: Annotated[str, "URL страницы"]) -> dict:
-    """Парсит страницу и возвращает только текст (без разметки)."""
-    resp = requests.get(url)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
-    text = soup.get_text(separator="\n", strip=True)
-    return {"text": text}
+from typing import Annotated, Callable
 
 import datetime
-
-# ─── Current Date ───
-@tool
-def current_date_tool() -> dict:
-    """Возвращает текущую дату в формате ГГГГ-ММ-ДД и день недели (на англ.)."""
-    now = datetime.datetime.now()
-    return {
-        "date":       now.strftime("%Y-%m-%d"),
-        "day_of_week": now.strftime("%A")
-    }
-
 import math
-
-# ─── Calculator ───
-@tool
-def calculator_tool(expression: Annotated[str, "Выражение для вычисления"]) -> dict:
-    """Вычисляет математическое выражение и возвращает результат."""
-    try:
-        # безопасный eval с доступом только к math.*
-        result = eval(expression, {"__builtins__": None}, math.__dict__)
-        return {"result": result}
-    except Exception as e:
-        return {"error": str(e)}
-
-
-@tool
-def send_email_tool(
-    recipient: Annotated[str, "email получателя"],
-    subject: Annotated[str, "тема письма"],
-    body: Annotated[str, "текст письма"],
-) -> dict:
-    """Отправляет email через SMTP Gmail."""
-    return {"status": "sent"}
-
-
-import os
+import requests
+from bs4 import BeautifulSoup
 from langchain_tavily import TavilySearch
 
-search_tool = TavilySearch(max_results=3)
-search_tool.name = "search_tool"
+
+def register_tools(decorate: Callable[..., Callable[[Callable], Callable]]) -> None:
+    """Register all available tools using the provided decorator factory."""
+
+    @decorate()
+    def response_tool(
+        response: Annotated[str, "сообщение для пользователя"]
+    ) -> dict:
+        """Отправить сообщение пользователю."""
+        return {"answer": response}
+
+    @decorate()
+    def read_webpage_tool(url: Annotated[str, "URL страницы"]) -> dict:
+        """Парсит страницу и возвращает только текст (без разметки)."""
+        resp = requests.get(url)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        text = soup.get_text(separator="\n", strip=True)
+        return {"text": text}
+
+    @decorate()
+    def current_date_tool() -> dict:
+        """Возвращает текущую дату и день недели (на англ.)."""
+        now = datetime.datetime.now()
+        return {"date": now.strftime("%Y-%m-%d"), "day_of_week": now.strftime("%A")}
+
+    @decorate()
+    def calculator_tool(
+        expression: Annotated[str, "Выражение для вычисления"]
+    ) -> dict:
+        """Вычисляет математическое выражение."""
+        try:
+            result = eval(expression, {"__builtins__": None}, math.__dict__)
+            return {"result": result}
+        except Exception as exc:  # noqa: BLE001
+            return {"error": str(exc)}
+
+    @decorate()
+    def send_email_tool(
+        recipient: Annotated[str, "email получателя"],
+        subject: Annotated[str, "тема письма"],
+        body: Annotated[str, "текст письма"],
+    ) -> dict:
+        """Отправляет email через SMTP Gmail."""
+        return {"status": "sent"}
+
+    tavily = TavilySearch(max_results=3)
+
+    @decorate(name="search_tool")
+    def search_tool(query: Annotated[str, "поисковый запрос"]) -> dict:
+        """Использует Tavily для поиска информации."""
+        return tavily.invoke({"query": query})
+
+
+__all__ = ["register_tools"]
+


### PR DESCRIPTION
## Summary
- register tools via a `register_tools` helper that applies the MCP decorator
- simplify `mcp_server` to register tools using `register_tools` and drop direct tool references

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement beautifulsoup4==4.13.4)*
- `pip install beautifulsoup4 langchain-core langchain-tavily mcp` *(fails: Could not find a version that satisfies the requirement beautifulsoup4)*
- `python -m py_compile mcp_server.py tools.py`
- `python mcp_server.py` *(fails: ModuleNotFoundError: No module named 'mcp')*


------
https://chatgpt.com/codex/tasks/task_e_68beb06bc1f883268aafc90ce5a04d12